### PR TITLE
相手のidを取得し試合ページへ移動する

### DIFF
--- a/src/main/java/oit/is/z1819/kaizi/janken/controller/JankenController.java
+++ b/src/main/java/oit/is/z1819/kaizi/janken/controller/JankenController.java
@@ -32,6 +32,13 @@ public class JankenController {
     return "janken.html";
   }
 
+  @GetMapping("/match")
+  public String match(@RequestParam String id , ModelMap model ) {
+      User opp = usermapper.selectById(id);
+      model.addAttribute("opponent", opp);
+      return "match.html";
+  }
+
   @GetMapping("/jankengame")
   public String jankengame(@RequestParam String hand, ModelMap model) {
     Janken janken = new Janken();

--- a/src/main/java/oit/is/z1819/kaizi/janken/model/UserMapper.java
+++ b/src/main/java/oit/is/z1819/kaizi/janken/model/UserMapper.java
@@ -7,13 +7,13 @@ import org.apache.ibatis.annotations.Select;
 
 @Mapper
 public interface UserMapper {
-    /*
-     * @Select("SELECT * from users where id = #{id}")
-     * User selectById(String id);
-     * 
-     * @Select("SELECT * from users where name = #{name}")
-     * User selectByName(String name);
-     */
+
+    @Select("SELECT * from users where id = #{id}")
+    User selectById(String id);
+
+    @Select("SELECT * from users where name = #{name}")
+    User selectByName(String name);
+
     @Select("SELECT * from users")
     ArrayList<User> selectAllUsers();
 }

--- a/src/main/resources/templates/janken.html
+++ b/src/main/resources/templates/janken.html
@@ -15,20 +15,8 @@
 
   <h2>エントリー</h2>
   <ul>
-    <li th:each="user : ${users}">[[${user.getUserName()}]]</li>
+    <li th:each="user : ${users}"><a th:href="@{/match(id=${user.id})}"> [[${user.getUserName()}]]</a></li>
   </ul>
-
-  <div>
-    <a href="/jankengame?hand=Gu">グー</a>
-    <a href="/jankengame?hand=Choki">チョキ</a>
-    <a href="/jankengame?hand=Pa">パー</a>
-  </div>
-
-  <div th:if="${result}">
-    <p>あなたの手 [[${player_hand}]]</p>
-    <p>相手の手 [[${cpu_hand}]]</p>
-    <p>結果 [[${result}]]</p>
-  </div>
 
   <h2>試合結果</h2>
   <div th:if="${matches}">

--- a/src/main/resources/templates/match.html
+++ b/src/main/resources/templates/match.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+
+<head>
+    <meta charset="utf-8">
+    <title>Janken</title>
+</head>
+
+<body>
+
+    <div><a href="/logout">ログアウト</a></div>
+
+    <h1>Match</h1>
+
+    <h2><span sec:authentication="name"></span> v.s [[${opponent.getUserName()}]]</h2>
+
+    <div>
+        <a href="/jankengame?hand=Gu">グー</a>
+        <a href="/jankengame?hand=Choki">チョキ</a>
+        <a href="/jankengame?hand=Pa">パー</a>
+    </div>
+
+    <div th:if="${result}">
+        <p>あなたの手 [[${player_hand}]]</p>
+        <p>相手の手 [[${cpu_hand}]]</p>
+        <p>結果 [[${result}]]</p>
+    </div>
+
+    <div><a href="/janken">戻る</a></div>
+
+</body>
+
+</html>


### PR DESCRIPTION
第2回の[Sample2-3]を参考に，GETリクエストを利用してmatch.htmlへ移動する処理を実装する
janken.htmlで[エントリー]に表示されている各ユーザを対戦相手とするGETリクエストのリンクを作成する．ログインしているユーザがそのリンクをクリックすると，match.htmlにログインユーザとクリックしたユーザの名前が表示される
Controllerに@GetMapping(“/match”)でメソッドを追加する
<li th:each="user : ${users}"><a th:href="@{/match(id=${user.id})}"> [[${user.name}]]</a></li>のように書くことでリンクにパラメータを埋め込むことができる
QueryParameterにidを与えることで対戦相手を特定するので，UserMapperにidを利用してUserオブジェクトを取得するメソッドを追加する
リンクは表示されているユーザすべてにつけるが，試合が行えるのはCPUのみでよい
[DoD]
“ほんだ”，でログインして http://localhost:8080/janken にアクセスし，エントリーの下に表示されるユーザ一覧からCPUをクリックすると，match.htmlが表示され，「ほんだ vs CPU」と表示されている