### PR TITLE
ログイン後にアクティブな試合を表示する

### DIFF
--- a/src/main/java/oit/is/z1819/kaizi/janken/controller/JankenController.java
+++ b/src/main/java/oit/is/z1819/kaizi/janken/controller/JankenController.java
@@ -13,6 +13,8 @@ import oit.is.z1819.kaizi.janken.model.Janken;
 import oit.is.z1819.kaizi.janken.model.User;
 import oit.is.z1819.kaizi.janken.model.UserMapper;
 import oit.is.z1819.kaizi.janken.model.Match;
+import oit.is.z1819.kaizi.janken.model.MatchInfo;
+import oit.is.z1819.kaizi.janken.model.MatchInfoMapper;
 import oit.is.z1819.kaizi.janken.model.MatchMapper;
 
 @Controller
@@ -22,14 +24,27 @@ public class JankenController {
   private UserMapper usermapper;
   @Autowired
   private MatchMapper matchmapper;
+  @Autowired
+  private MatchInfoMapper matchinfomapper;
 
   @GetMapping("/janken")
-  public String janken(Principal prin, ModelMap model) {
-    ArrayList<User> users = usermapper.selectAllUsers();
-    model.addAttribute("users", users);
-    ArrayList<Match> matches = matchmapper.selectAllMatches();
-    model.addAttribute("matches", matches);
-    return "janken.html";
+  public String janken(ModelMap model) {
+      ArrayList<User> users = usermapper.selectAllUsers();
+      ArrayList<Match> matches = matchmapper.selectAllMatches();
+
+      ArrayList<MatchInfo> activeMatches = matchinfomapper.selectActiveMatches();
+      ArrayList<Result> results  = new ArrayList<>();
+
+      for (Match match : matches) {
+          Result result = new Result(match);
+          results.add(result);
+      }
+      model.addAttribute("users", users);
+      model.addAttribute("history", results);
+
+      model.addAttribute("activematches", activeMatches);
+
+      return "janken.html";
   }
 
   @GetMapping("/match")
@@ -38,24 +53,65 @@ public class JankenController {
       model.addAttribute("opponent", opp);
       return "match.html";
   }
+
+  @GetMapping("/wait")
+  public String wait(@RequestParam String id, @RequestParam String hand, ModelMap model, Principal prin) {
+      String user1name = prin.getName();
+      int user1 = usermapper.selectByName(user1name).getId();
+      int user2 = Integer.parseInt(id);
+
+      MatchInfo matchinfo = new MatchInfo();
+      matchinfo.setUser1(user1);
+      matchinfo.setUser2(user2);
+      matchinfo.setUser1Hand(hand);
+      matchinfo.setActive(true);
+      matchinfomapper.insertMatchInfo(matchinfo);
+
+      return "wait.html";
+  }
   
   @GetMapping("/fight")
-  public String game(@RequestParam String id, @RequestParam String hand, ModelMap model, Principal prin) {
-    Match match = new Match();
-    Janken janken = new Janken();
-    janken.setPlayer(hand);
-    janken.setCpu();
+  public String game(@RequestParam String id, @RequestParam String hand , ModelMap model, Principal prin) {
+      Match match = new Match();
+      Janken janken = new Janken();
+      janken.setPlayer1(hand);
 
-    match.setUser1(usermapper.selectByName(prin.getName()).getId());
-    match.setUser2(Integer.parseInt(id));
-    match.setUser1Hand(janken.getPlayer());
-    match.setUser2Hand(janken.getCpu());
-    matchmapper.insertMatch(match);
+      match.setUser1(usermapper.selectByName(prin.getName()).getId());
+      match.setUser2(Integer.parseInt(id));
+      match.setUser1Hand(janken.getPlayer1());
+      match.setUser2Hand(janken.getPlayer2());
+      match.setisActive(false);
+      matchmapper.insertMatch(match);
 
-    model.addAttribute("opponent", usermapper.selectById(id));
-    model.addAttribute("player_hand", janken.getPlayer());
-    model.addAttribute("cpu_hand", janken.getCpu());
-    model.addAttribute("result", janken.jankenResult());
-    return "match.html";
+      model.addAttribute("opponent", usermapper.selectById(id));
+      model.addAttribute("player1", janken.getPlayer1());
+      model.addAttribute("player2", janken.getPlayer2());
+      model.addAttribute("result", janken.jankenResult());
+
+      return "match.html";
   }
+}
+
+/**
+ * じゃんけんの結果を格納するクラス
+ */
+class Result extends Match {
+    private String result;
+    public Result(Match match) {
+        super.setId(match.getId());
+        super.setUser1(match.getUser1());
+        super.setUser2(match.getUser2());
+        super.setUser1Hand(match.getUser1Hand());
+        super.setUser2Hand(match.getUser2Hand());
+        Janken game = new Janken();
+        game.setPlayer1(match.getUser1Hand());
+        game.setPlayer2(match.getUser2Hand());
+        if (game.jankenResult() == null) {
+            this.setResult("引き分け");
+        } else {
+            this.setResult(game.jankenResult() + "の勝利");
+        }
+    }
+    public void setResult(String result) { this.result = result; }
+    public String getResult() { return this.result; }
 }

--- a/src/main/java/oit/is/z1819/kaizi/janken/model/Janken.java
+++ b/src/main/java/oit/is/z1819/kaizi/janken/model/Janken.java
@@ -5,14 +5,23 @@ import java.util.Random;
 //@Controller
 public class Janken {
   private String cpu;
-  private String player;
+  private String player1;
+  private String player2;
 
-  public void setPlayer(String hand) {
-    this.player = hand;
+  public void setPlayer1(String hand) {
+    this.player1 = hand;
   }
 
-  public String getPlayer() {
-    return this.player;
+  public String getPlayer1() {
+    return this.player1;
+  }
+
+  public void setPlayer2(String hand) {
+    this.player2 = hand;
+  }
+
+  public String getPlayer2() {
+    return this.player2;
   }
 
   public void setCpu() {
@@ -35,12 +44,12 @@ public class Janken {
   }
 
   public String jankenResult() {
-    if (this.player.equals(this.cpu)) {
+    if (this.player1.equals(this.player2)) {
       return "Drow";
     }
-    if ((this.player.equals("Gu") && this.cpu.equals("Choki")) ||
-        (this.player.equals("Choki") && this.cpu.equals("Pa")) ||
-        (this.player.equals("Pa") && this.cpu.equals("Gu"))) {
+    if ((this.player1.equals("Gu") && this.player2.equals("Choki")) ||
+        (this.player1.equals("Choki") && this.player2.equals("Pa")) ||
+        (this.player1.equals("Pa") && this.player2.equals("Gu"))) {
       return "You Win!";
     }
     return "You Lose";

--- a/src/main/java/oit/is/z1819/kaizi/janken/model/MatchInfo.java
+++ b/src/main/java/oit/is/z1819/kaizi/janken/model/MatchInfo.java
@@ -1,0 +1,49 @@
+package oit.is.z1819.kaizi.janken.model;
+
+public class MatchInfo {
+    private int id;
+    private int user1;
+    private int user2;
+    private String user1Hand;
+    private boolean isActive;
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public int getUser1() {
+        return user1;
+    }
+
+    public void setUser1(int user1) {
+        this.user1 = user1;
+    }
+
+    public int getUser2() {
+        return user2;
+    }
+
+    public void setUser2(int user2) {
+        this.user2 = user2;
+    }
+
+    public String getUser1Hand() {
+        return user1Hand;
+    }
+
+    public void setUser1Hand(String user1Hand) {
+        this.user1Hand = user1Hand;
+    }
+
+    public boolean isActive() {
+        return isActive;
+    }
+
+    public void setActive(boolean active) {
+        isActive = active;
+    }
+}

--- a/src/main/java/oit/is/z1819/kaizi/janken/model/MatchInfoMapper.java
+++ b/src/main/java/oit/is/z1819/kaizi/janken/model/MatchInfoMapper.java
@@ -1,0 +1,16 @@
+package oit.is.z1819.kaizi.janken.model;
+
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Select;
+
+import java.util.ArrayList;
+
+@Mapper
+public interface MatchInfoMapper {
+    @Insert("INSERT INTO MATCHINFO (USER1, USER2, USER1HAND, ISACTIVE)  VALUES (#{user1}, #{user2}, #{user1Hand}, #{isActive})")
+    boolean insertMatchInfo(MatchInfo matchInfo);
+
+    @Select("SELECT * FROM MATCHINFO WHERE ISACTIVE = TRUE")
+    ArrayList<MatchInfo> selectActiveMatches();
+}

--- a/src/main/java/oit/is/z1819/kaizi/janken/model/MatchMapper.java
+++ b/src/main/java/oit/is/z1819/kaizi/janken/model/MatchMapper.java
@@ -9,13 +9,13 @@ import org.apache.ibatis.annotations.Select;
 
 @Mapper
 public interface MatchMapper {
-    @Select("SELECT * from matches")
-    ArrayList<Match> selectAllMatches();
+    @Select("SELECT id, user1, user2, user1Hand, user2Hand, isActive from matches")
+    ArrayList <Match> selectAllMatches();
 
-    @Select("SELECT * from matchinfo")
-    ArrayList<Match> selectByMatchinfo();
+    @Select("SELECT id, user1, user2, user1Hand, user2Hand, isActive from matches where isActive = true")
+    Match selectActiveMatch();
 
-    @Insert("INSERT INTO matches (user1, user2, user1Hand, user2Hand, isAvtive) VALUES (#{user1}, #{user2}, #{user1Hand}, #{user2Hand}, #{isActive})")
+    @Insert("INSERT INTO matches (user1, user2, user1Hand, user2Hand, isActive) VALUES (#{user1}, #{user2}, #{user1Hand}, #{user2Hand}, #{isActive})")
     @Options(useGeneratedKeys = true, keyColumn = "id", keyProperty = "id")
     void insertMatch(Match match);
 }

--- a/src/main/resources/templates/janken.html
+++ b/src/main/resources/templates/janken.html
@@ -18,19 +18,25 @@
     <li th:each="user : ${users}"><a th:href="@{/match(id=${user.id})}"> [[${user.getUserName()}]]</a></li>
   </ul>
 
+  <h2>アクティブな試合</h2>
+  <table th:each="active:${activematches}">
+      <tr>
+          <td>id:[[${active.id}]]</td>
+          <td>user1:[[${active.user1}]]</td>
+          <td>user2:[[${active.user2}]]</td>
+          <td>isActive:[[${active.isActive}]]</td>
+      </tr>
+  </table>
   <h2>試合結果</h2>
-  <div th:if="${matches}">
-    <ul>
-      <li th:each="match : ${matches}">
-        <td>id:[[${match.getId()}]]</td>
-        <td>user1:[[${match.getUser1()}]]</td>
-        <td>user2:[[${match.getUser2()}]]</td>
-        <td>user1の手:[[${match.getUser1Hand()}]]</td>
-        <td>user2の手:[[${match.getUser2Hand()}]]</td>
-      </li>
-    </ul>
-  </div>
-
+  <table th:each="match:${history}">
+      <tr>
+          <td>id:[[${match.id}]]</td>
+          <td>user1:[[${match.user1}]]</td>
+          <td>user2:[[${match.user2}]]</td>
+          <td>user1の手:[[${match.user1Hand}]]</td>
+          <td>user2の手:[[${match.user2Hand}]]</td>
+          <td>結果: <span th:text="${match.result}" /></td>
+      </tr>
+  </table>
 </body>
-
 </html>

--- a/src/main/resources/templates/match.html
+++ b/src/main/resources/templates/match.html
@@ -14,9 +14,9 @@
     <h2><span sec:authentication="name"></span> v.s [[${opponent.getUserName()}]]</h2>
 
     <div>
-        <a th:href="@{/fight(id=${opponent.id}, hand='Gu')}">グー</a>
-        <a th:href="@{/fight(id=${opponent.id}, hand='Choki')}">チョキ</a>
-        <a th:href="@{/fight(id=${opponent.id}, hand='Pa')}">パー</a>
+        <a th:href="@{/wait(id=${opponent.id}, hand='Gu')}">グー</a>
+        <a th:href="@{/wait(id=${opponent.id}, hand='Choki')}">チョキ</a>
+        <a th:href="@{/wait(id=${opponent.id}, hand='Pa')}">パー</a>
     </div>
 
     <div th:if="${result}">

--- a/src/main/resources/templates/wait.html
+++ b/src/main/resources/templates/wait.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <title>Janken</title>
+</head>
+
+<body>
+    <div><a href="/logout">ログアウト</a></div><br>
+    <h1>相手の手を待ってます</h1>
+    <p>Hi <span sec:authentication="name"></span></p>
+
+    <a href="/janken">戻る</a>
+
+</body>
+</html>


### PR DESCRIPTION
第4回の[Sample4-5:複数のレコードをDBから取得する処理を実装する]を参考に，「ほんだ」でログイン後の画面でmatchinfoテーブルのisActiveがtrueとして登録される試合を表示する
流れ
「いがき」でログインし，jankenのページのエントリーから「ほんだ」を選び，matchのページで手を選び，waitのページに遷移する
シークレットモードで「ほんだ」でログインし，jankenのページでアクティブな試合について「id:(MatchInfoのidが表示される) user1:(MatchInfoのuser1が表示される) user2:(MatchInfoのuser1が表示される) isActive:(MatchInfoのisActiveが表示される)」の様に表示される
[DoD]
「いがき」でログインし，jankenのページのエントリーから「ほんだ」を選び，matchのページで手を選び，waitのページに遷移する
シークレットモードで「ほんだ」でログインし，jankenのページでアクティブな試合について「id:(MatchInfoのidが表示される) user1:(MatchInfoのuser1が表示される) user2:(MatchInfoのuser1が表示される) isActive:(MatchInfoのisActiveが表示される)」の様に表示される